### PR TITLE
fix: replace hardcoded anthropic provider in instructions with dynamic values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,10 @@ const defaultModel = process.env.OPENCODE_DEFAULT_MODEL;
 // Set global model defaults from env vars (used by applyModelDefaults() in tools)
 setModelDefaults(defaultProvider, defaultModel);
 
+// Use env-var defaults in instruction examples; fall back to generic placeholders
+const exProvider = defaultProvider || "<your-provider>";
+const exModel = defaultModel || "<your-model>";
+
 const client = new OpenCodeClient({ baseUrl, username, password, autoServe });
 
 const server = new McpServer(
@@ -82,8 +86,8 @@ const server = new McpServer(
       "",
       "## Getting Started (First Time)",
       "1. Call `opencode_setup` — checks server health, shows configured providers, and suggests next steps.",
-      "2. Call `opencode_provider_models({providerId: 'anthropic'})` — lists available models for a provider.",
-      "3. Pick a provider and model. IMPORTANT: Always pass `providerID` and `modelID` when sending prompts, or you may get empty responses.",
+      "2. Pick a provider from the **Ready to use** list returned by `opencode_setup`, then call `opencode_provider_models` to see its models.",
+      "3. IMPORTANT: Always pass `providerID` and `modelID` from the discovered providers when sending prompts, or you may get empty responses. Do NOT assume any specific provider is available — always discover first.",
       "",
       "## Tool Tiers (prefer higher tiers)",
       "",
@@ -124,16 +128,16 @@ const server = new McpServer(
       "",
       "### Quick question or small task:",
       "```",
-      'opencode_ask({prompt: "How does auth work in this project?", providerID: "anthropic", modelID: "claude-sonnet-4-5"})',
+      `opencode_ask({prompt: "How does auth work in this project?", providerID: "${exProvider}", modelID: "${exModel}"})`,
       "```",
       "",
       "### Complex multi-step task (build an app, refactor code, etc.):",
       "```",
       "// Option A: One-call (recommended for tasks under 10 min)",
-      'opencode_run({prompt: "Build a React login form with validation...", providerID: "anthropic", modelID: "claude-opus-4-6", maxDurationSeconds: 600})',
+      `opencode_run({prompt: "Build a React login form with validation...", providerID: "${exProvider}", modelID: "${exModel}", maxDurationSeconds: 600})`,
       "",
       "// Option B: Fire-and-forget (for longer tasks)",
-      'opencode_fire({prompt: "Build a full React app with auth, dashboard...", providerID: "anthropic", modelID: "claude-opus-4-6"})',
+      `opencode_fire({prompt: "Build a full React app with auth, dashboard...", providerID: "${exProvider}", modelID: "${exModel}"})`,
       "// ... do other work ...",
       'opencode_check({sessionId: "ses_xxx"})  // quick progress check',
       'opencode_review_changes({sessionId: "ses_xxx"})  // see changes after completion',
@@ -141,7 +145,7 @@ const server = new McpServer(
       "",
       "### Continue working on an existing session:",
       "```",
-      'opencode_reply({sessionId: "ses_xxx", prompt: "Now add form validation", providerID: "anthropic", modelID: "claude-sonnet-4-5"})',
+      `opencode_reply({sessionId: "ses_xxx", prompt: "Now add form validation", providerID: "${exProvider}", modelID: "${exModel}"})`,
       "```",
       "",
       "## Permissions",
@@ -151,7 +155,7 @@ const server = new McpServer(
       "- You can also set permissions at runtime: `opencode_config_update({config: {permission: \"allow\"}})`",
       "",
       "## Important Notes",
-      "- ALWAYS specify `providerID` and `modelID` when using `opencode_ask`, `opencode_reply`, `opencode_message_send`, or `opencode_message_send_async`. Without these, the agent may return empty responses. If OPENCODE_DEFAULT_PROVIDER and OPENCODE_DEFAULT_MODEL env vars are set, they will be used as fallbacks when you don't specify them.",
+      "- ALWAYS specify `providerID` and `modelID` when using `opencode_ask`, `opencode_reply`, `opencode_message_send`, or `opencode_message_send_async`. Without these, the agent may return empty responses. Use providers and models discovered via `opencode_setup` — do NOT hardcode any specific provider. If `OPENCODE_DEFAULT_PROVIDER` and `OPENCODE_DEFAULT_MODEL` env vars are set, they will be used as fallbacks when you don't specify them.",
       "- The `directory` parameter on every tool targets a specific project. Omit it to use the server's default project. Must be an absolute path to an existing directory — relative paths and non-existent paths are rejected with a helpful error.",
       "- Tools marked with `readOnlyHint: true` in their annotations are safe and don't modify state.",
       "- Tools marked with `destructiveHint: true` (`opencode_instance_dispose`, `opencode_session_delete`) permanently delete data — confirm with the user before calling.",

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -158,13 +158,13 @@ Steps:
 
 ## 1. First-Time Setup
 - Always start with \`opencode_setup\` to check server health and see available providers.
-- Use \`opencode_provider_models({providerId: "anthropic"})\` to see which models are available.
-- Test a provider with \`opencode_provider_test({providerId: "anthropic"})\` if you're unsure it's working.
+- Pick a provider from the **Ready to use** list, then call \`opencode_provider_models\` to see its models.
+- Test a provider with \`opencode_provider_test\` if you're unsure it's working.
 
 ## 2. Always Specify Provider and Model
-CRITICAL: When calling \`opencode_ask\`, \`opencode_reply\`, \`opencode_message_send\`, or \`opencode_message_send_async\`, ALWAYS pass \`providerID\` and \`modelID\`. Without these, the agent may select a default model that returns empty responses.
+CRITICAL: When calling \`opencode_ask\`, \`opencode_reply\`, \`opencode_message_send\`, or \`opencode_message_send_async\`, ALWAYS pass \`providerID\` and \`modelID\`. Without these, the agent may select a default model that returns empty responses. Use providers discovered via \`opencode_setup\` — do NOT hardcode any specific provider.
 
-Good: \`opencode_ask({prompt: "...", providerID: "anthropic", modelID: "claude-sonnet-4-5"})\`
+Good: \`opencode_ask({prompt: "...", providerID: "<your-provider>", modelID: "<your-model>"})\`
 Bad: \`opencode_ask({prompt: "..."})\`
 
 ## 3. Choosing the Right Tool


### PR DESCRIPTION
## Summary

- MCP server instructions and best-practices prompt hardcoded `anthropic` / `claude-sonnet-4-5` in all example code blocks, causing LLM clients to always default to Anthropic even when users have different providers configured
- Instruction examples now use `OPENCODE_DEFAULT_PROVIDER` / `OPENCODE_DEFAULT_MODEL` env vars when set, falling back to generic `<your-provider>` / `<your-model>` placeholders
- "Getting Started" section now directs LLMs to call `opencode_setup` first to discover available providers instead of assuming any specific one

Fixes #1

## Changes

**`src/index.ts`**
- Added `exProvider` / `exModel` variables derived from env vars or generic placeholders
- Replaced all 5 hardcoded `anthropic` / `claude-sonnet-4-5` / `claude-opus-4-6` references in instruction examples
- Updated "Getting Started" to guide LLMs to discover providers via `opencode_setup`
- Updated "Important Notes" to emphasize using discovered providers

**`src/prompts.ts`**
- Replaced hardcoded `anthropic` references in the best-practices prompt with generic guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance to recommend discovering available providers and models through the setup process instead of hardcoding specific providers.
  * Enhanced best practices examples with generic provider and model placeholders for greater flexibility across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->