### PR TITLE
fix(helpers): accept Windows absolute paths in normalizeDirectory

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,7 +8,7 @@
 
 import { z } from "zod";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -81,9 +81,14 @@ export function applyModelDefaults(
 
 /**
  * Normalize and validate a directory path:
- *  - Resolves to absolute (handles "..", trailing slashes, etc.)
- *  - Rejects relative paths (must start with /)
+ *  - Resolves to absolute (handles "..", ".", trailing slashes, and
+ *    converts relative inputs against `process.cwd()`)
+ *  - Confirms the resolved path is absolute for the current platform
  *  - Validates that the path exists on disk
+ *
+ * Accepts both POSIX ("/home/user/my-project") and Windows
+ * ("C:\\Users\\me\\my-project", "\\\\server\\share") absolute paths via
+ * the platform-aware `resolve` + `isAbsolute` from `node:path`.
  *
  * Returns the normalized path, or undefined if input was undefined.
  * Throws a descriptive Error on validation failure.
@@ -91,14 +96,19 @@ export function applyModelDefaults(
 export function normalizeDirectory(directory?: string): string | undefined {
   if (!directory) return undefined;
 
-  // Resolve to absolute (handles "..", ".", trailing slashes)
+  // Resolve to an absolute, platform-appropriate form. `resolve` handles
+  // "..", ".", trailing slashes, and will convert a relative input against
+  // `process.cwd()`.
   const normalized = resolve(directory);
 
-  // Must be an absolute path
-  if (!normalized.startsWith("/")) {
+  // Defensive check: `resolve` guarantees an absolute path on every
+  // supported platform, but we verify via the platform-aware `isAbsolute`
+  // so callers get a clear error if that assumption is ever violated.
+  if (!isAbsolute(normalized)) {
     throw new Error(
       `Invalid directory: "${directory}" is not an absolute path. ` +
-        `Provide a full path like "/home/user/my-project".`,
+        `Provide a full path like "/home/user/my-project" (POSIX) or ` +
+        `"C:\\\\Users\\\\me\\\\my-project" (Windows).`,
     );
   }
 

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -927,6 +927,29 @@ describe("normalizeDirectory", () => {
     const result = normalizeDirectory("/tmp");
     expect(result).toBe("/tmp");
   });
+
+  it("accepts the process working directory on any platform", () => {
+    // Platform-agnostic regression: process.cwd() is always absolute for the
+    // current platform, so normalizeDirectory must accept it regardless of OS.
+    const result = normalizeDirectory(process.cwd());
+    expect(result).toBeDefined();
+  });
+
+  // Regression for Windows drive-letter paths.
+  // Before the fix, normalizeDirectory required the resolved path to start
+  // with "/", which meant Windows absolute paths like "C:\\Users\\..." were
+  // rejected. The fix switches to the platform-aware `path.isAbsolute`, so
+  // this test guards the Windows path on a Windows CI runner.
+  it.runIf(process.platform === "win32")(
+    "accepts Windows drive-letter absolute paths",
+    () => {
+      const cwd = process.cwd(); // e.g. "C:\\Users\\runner\\work\\..."
+      expect(cwd).toMatch(/^[A-Za-z]:\\/);
+      const result = normalizeDirectory(cwd);
+      expect(result).toBeDefined();
+      expect(result).toMatch(/^[A-Za-z]:\\/);
+    },
+  );
 });
 
 // ─── diagnoseError (via toolError) ───────────────────────────────────────


### PR DESCRIPTION
Closes #5.

## Summary

`normalizeDirectory` checked the resolved path with `normalized.startsWith(\"/\")`, which is only correct on POSIX. On Windows, `path.resolve` returns drive-letter paths like `C:\Users\me\project`, so every Windows absolute path was rejected and the `directory` parameter was effectively unusable for Windows MCP clients (all 79 tools affected).

This PR switches the check to the platform-aware `path.isAbsolute` from `node:path`. `path.resolve` already guarantees an absolute path on every supported platform, so the new check is equivalent on POSIX (behavior unchanged) and correct on Windows.

## Changes

- `src/helpers.ts`
  - Import `isAbsolute` from `node:path`.
  - Replace `normalized.startsWith(\"/\")` with `!isAbsolute(normalized)`.
  - Extend the error message to include a Windows example alongside the POSIX one.
  - Update the JSDoc to describe the POSIX + Windows support.
- `tests/helpers.test.ts`
  - New test: `accepts the process working directory on any platform` — a platform-agnostic regression that passes `process.cwd()` through `normalizeDirectory`. With the old code this test fails on Windows (cwd is `C:\...`) and passes on Linux; with the new code it passes on both.
  - New test (skipped on non-Windows via `it.runIf`): `accepts Windows drive-letter absolute paths` — asserts that a real Windows drive-letter path is accepted and round-trips through the function.

No runtime dependencies added. No public API change. POSIX semantics unchanged.

## Test results

Run on Windows 11 with Node 22, `npm test`:

- Baseline (`upstream/main`): **20 failing / 300 passing / 320 total**
- This branch: **13 failing / 309 passing / 322 total** (2 new tests added)

The fix itself turns 7 previously-failing Windows tests green (the ones exercising `normalizeDirectory` via the tool handlers with Linux-style paths that resolve to the current drive but then hit the absolute-path check incorrectly). The remaining 13 failures on Windows are pre-existing and unrelated to this fix — they hardcode Linux paths like `/tmp` into string comparisons (e.g. `expect(result).toBe(\"/tmp\")`), which can't succeed on Windows where `resolve(\"/tmp\")` returns `X:\tmp`. Happy to file a follow-up PR making those tests platform-agnostic if you want, but I kept this PR scoped to the actual bug.

On Linux, the full suite is unchanged by these changes — the new platform-agnostic test passes (cwd is absolute on Linux too), and the Windows-only test is skipped via `it.runIf(process.platform === \"win32\")`.

## Workaround that this replaces

Before this fix, the only way to make opencode-mcp usable on Windows was to omit the `directory` parameter entirely and rely on the cwd of the process that spawned `opencode serve`. That works for single-project setups but defeats the point of the per-request `directory` header in multi-project setups.

## Conventional Commits

`fix(helpers): accept Windows absolute paths in normalizeDirectory`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Path normalization now correctly validates and handles absolute paths on all platforms, including Windows drive-letter format paths and standard POSIX paths, with improved error messages that cover platform-specific path examples.
* **Tests**
  * Added regression tests to verify platform-specific absolute path validation functions correctly on both Windows and POSIX systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->