### PR TITLE
feat: add OPENCODE_SERVE_ARGS env var support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@
  *   OPENCODE_AUTO_SERVE       - Set to "false" to disable auto-start (default: true)
  *   OPENCODE_DEFAULT_PROVIDER - Default provider ID when not specified per-tool (optional)
  *   OPENCODE_DEFAULT_MODEL    - Default model ID when not specified per-tool (optional)
+ *   OPENCODE_SERVE_ARGS       - Extra arguments for the `opencode serve` auto-start (optional)
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -204,6 +204,14 @@ export async function startServer(
     args.push("--hostname", hostname);
   }
 
+  // Allow passing custom parameters to `opencode serve`
+  if (process.env.OPENCODE_SERVE_ARGS) {
+    const extraArgs = process.env.OPENCODE_SERVE_ARGS.match(/[^\s"']+|"([^"]*)"|'([^']*)'/g) || [];
+    for (const arg of extraArgs) {
+      args.push(arg.replace(/^['"]|['"]$/g, ""));
+    }
+  }
+
   const child = spawn(binaryPath, args, {
     stdio: ["ignore", "pipe", "pipe"],
     detached: false,


### PR DESCRIPTION
Fixes #7. Thanks @xpufx for the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `OPENCODE_SERVE_ARGS` environment variable to pass custom arguments to the serve command at startup.

* **Documentation**
  * Added documentation for the new `OPENCODE_SERVE_ARGS` environment variable configuration option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AlaeddineMessadi/opencode-mcp/pull/9)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->